### PR TITLE
Use getErrorOutput() to determine failed result

### DIFF
--- a/src/CheckDefinitions/CheckDefinition.php
+++ b/src/CheckDefinitions/CheckDefinition.php
@@ -34,7 +34,7 @@ abstract class CheckDefinition
         $this->check->storeProcessOutput($process);
 
         try {
-            if (! $process->isSuccessful()) {
+            if (! empty($process->getErrorOutput())) {
                 $this->resolveFailed($process);
 
                 return;


### PR DESCRIPTION
isSuccessfull() uses exit code to determine status (see https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Process/Process.php#L726). This can lead to a false positive failed result. It's better to check if getErrorCode() is not empty.