### PR TITLE
Don't show download output for curl command

### DIFF
--- a/src/CheckDefinitions/Elasticsearch.php
+++ b/src/CheckDefinitions/Elasticsearch.php
@@ -6,7 +6,7 @@ use Symfony\Component\Process\Process;
 
 final class Elasticsearch extends CheckDefinition
 {
-    public $command = 'curl http://localhost:9200';
+    public $command = 'curl --silent http://localhost:9200';
 
     public function resolve(Process $process)
     {


### PR DESCRIPTION
This fixes #29 and should really be in there so you don't get output that you don't want.

Thanks.