### PR TITLE
Set the Event on the Notifiable

### DIFF
--- a/src/Notifications/EventHandler.php
+++ b/src/Notifications/EventHandler.php
@@ -36,6 +36,8 @@ class EventHandler
             if ($notification->shouldSend()) {
                 $notifiable = $this->determineNotifiable();
 
+                $notifiable->setEvent($event);
+
                 $notifiable->notify($notification);
             }
 

--- a/src/Notifications/Notifiable.php
+++ b/src/Notifications/Notifiable.php
@@ -8,6 +8,9 @@ class Notifiable
 {
     use NotifiableTrait;
 
+    /** @var \Spatie\ServerMonitor\Events\Event */
+    protected $event;
+
     public function routeNotificationForMail(): ?string
     {
         return config('server-monitor.notifications.mail.to');
@@ -22,4 +25,30 @@ class Notifiable
     {
         return static::class;
     }
+
+    /**
+     * Get the event for the notification.
+     *
+     * @return \Spatie\ServerMonitor\Events\Event
+     */
+    public function getEvent(): \Spatie\ServerMonitor\Events\Event
+    {
+        return $this->event;
+    }
+
+    /**
+     * Set the event for the notification.
+     *
+     * @param \Spatie\ServerMonitor\Events\Event $event
+     *
+     * @return Notifiable
+     */
+    public function setEvent(\Spatie\ServerMonitor\Events\Event $event): Notifiable
+    {
+        $this->event = $event;
+
+        return $this;
+    }
+
+
 }

--- a/src/Notifications/Notifiable.php
+++ b/src/Notifications/Notifiable.php
@@ -49,6 +49,4 @@ class Notifiable
 
         return $this;
     }
-
-
 }

--- a/tests/Notifications/NotifiableTest.php
+++ b/tests/Notifications/NotifiableTest.php
@@ -2,12 +2,10 @@
 
 namespace Spatie\ServerMonitor\Test\Integration\Notifications;
 
-use Notification;
 use Spatie\ServerMonitor\Models\Check;
 use Spatie\ServerMonitor\Test\TestCase;
 use Spatie\ServerMonitor\Events\CheckSucceeded;
 use Spatie\ServerMonitor\Notifications\Notifiable;
-
 
 class NotifiableTest extends TestCase
 {
@@ -34,7 +32,5 @@ class NotifiableTest extends TestCase
         $notifiable->setEvent($event);
 
         $this->assertEquals($notifiable->getEvent(), $event);
-
     }
-
 }

--- a/tests/Notifications/NotifiableTest.php
+++ b/tests/Notifications/NotifiableTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Spatie\ServerMonitor\Test\Integration\Notifications;
+
+use Notification;
+use Spatie\ServerMonitor\Models\Check;
+use Spatie\ServerMonitor\Test\TestCase;
+use Spatie\ServerMonitor\Events\CheckSucceeded;
+use Spatie\ServerMonitor\Notifications\Notifiable;
+
+
+class NotifiableTest extends TestCase
+{
+    /** @var \Spatie\ServerMonitor\Models\Check */
+    protected $check;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->createHost('my-host', null, ['diskspace']);
+
+        $this->check = Check::first();
+    }
+
+    /** @test */
+    public function it_allows_an_event_to_be_passed_to_the_notifiable_class()
+    {
+        $event = \Mockery::mock(CheckSucceeded::class);
+
+        /** @var Notifiable $notifiable */
+        $notifiable = app($this->app['config']->get('server-monitor.notifications.notifiable'));
+
+        $notifiable->setEvent($event);
+
+        $this->assertEquals($notifiable->getEvent(), $event);
+
+    }
+
+}


### PR DESCRIPTION
Allowing setting the event onto the notifiable before processing.

This will allow for dynamic channels to be used instead of the config setting.