### PR TITLE
Add configurable table names (issue #36)

### DIFF
--- a/config/server-monitor.php
+++ b/config/server-monitor.php
@@ -76,4 +76,16 @@ return [
      * This class should implement Spatie\ServerMonitor\Manipulators\Manipulator
      */
     'process_manipulator' => Spatie\ServerMonitor\Manipulators\Passthrough::class,
+
+    /*
+     * Database table name for the Host and Check models.
+     *
+     * If you decide to change the database table name(s) after running the initial migrations,
+     * you will need to create a new migration to rename the table(s).
+     *
+     * eg. Schema::rename('hosts', 'my_custom_hosts');
+     */
+    'hosts_table' => 'hosts',
+
+    'checks_table' => 'checks',
 ];

--- a/database/migrations/create_checks_table.php.stub
+++ b/database/migrations/create_checks_table.php.stub
@@ -12,10 +12,11 @@ class CreateChecksTable extends Migration
      */
     public function up()
     {
-        Schema::create('checks', function (Blueprint $table) {
+        Schema::create(config('server-monitor.checks_table'), function (Blueprint $table) {
             $table->increments('id');
             $table->integer('host_id')->unsigned();
-            $table->foreign('host_id')->references('id')->on('hosts')->onDelete('cascade');
+            $table->foreign('host_id')->references('id')
+                ->on(config('server-monitor.hosts_table'))->onDelete('cascade');
             $table->string('type');
             $table->string('status')->nullable();
             $table->boolean('enabled')->default(true);
@@ -36,6 +37,6 @@ class CreateChecksTable extends Migration
      */
     public function down()
     {
-        Schema::drop('checks');
+        Schema::drop(config('server-monitor.checks_table'));
     }
 }

--- a/database/migrations/create_hosts_table.php.stub
+++ b/database/migrations/create_hosts_table.php.stub
@@ -12,7 +12,7 @@ class CreateHostsTable extends Migration
      */
     public function up()
     {
-        Schema::create('hosts', function (Blueprint $table) {
+        Schema::create(config('server-monitor.hosts_table'), function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
             $table->string('ssh_user')->nullable();
@@ -30,6 +30,6 @@ class CreateHostsTable extends Migration
      */
     public function down()
     {
-        Schema::drop('hosts');
+        Schema::drop(config('server-monitor.hosts_table'));
     }
 }

--- a/src/Models/Check.php
+++ b/src/Models/Check.php
@@ -41,6 +41,11 @@ class Check extends Model
         return $this->belongsTo(Host::class);
     }
 
+    public function getTable()
+    {
+        return config('server-monitor.checks_table');
+    }
+
     public function scopeHealthy($query)
     {
         return $query->where('status', CheckStatus::SUCCESS);

--- a/src/Models/Host.php
+++ b/src/Models/Host.php
@@ -25,6 +25,11 @@ class Host extends Model
         return $this->hasMany(Check::class);
     }
 
+    public function getTable()
+    {
+        return config('server-monitor.hosts_table');
+    }
+
     public function getEnabledChecksAttribute(): Collection
     {
         return $this->checks()->enabled()->get();


### PR DESCRIPTION
Changes:
- Added the ability to customize database table for `hosts` and `checks` names using the config file

I was able to complete the unit tests without any issue (although I received a few "skips" as I didn't have the local SSH server configured)