### PR TITLE
Added Skipping SSH Warnings After Connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ return [
          */
         'throttle_failing_notifications_for_minutes' => 60,
 
+        // Separate the email by , to add many recipients
         'mail' => [
             'to' => 'your@email.com',
         ],
@@ -119,6 +120,13 @@ return [
     ],
 
     /*
+     * To add or modify behaviour to the `Host` model you can specify your
+     * own model here. The only requirement is that they should
+     * extend the `Host` model provided by this package.
+     */
+    'host_model' => Spatie\ServerMonitor\Models\Host::class,
+
+    /*
      * To add or modify behaviour to the `Check` model you can specify your
      * own model here. The only requirement is that they should
      * extend the `Check` model provided by this package.
@@ -133,7 +141,20 @@ return [
      * This class should implement Spatie\ServerMonitor\Manipulators\Manipulator
      */
     'process_manipulator' => Spatie\ServerMonitor\Manipulators\Passthrough::class,
-    
+
+
+    /*
+     * When you connect to a ssh it should give you warning like a "POSSIBLE BREAK-IN ATTEMPT!"
+     * and it can fail your check so you can skip some errors with this. You need to just add
+     * unique part of error string and it will skip it.
+     */
+    'excluded_errors'=>[
+
+        "POSSIBLE BREAK-IN ATTEMPT!",
+
+    ],
+
+
     /*
      * Thresholds for disk space's alert.
      */

--- a/config/server-monitor.php
+++ b/config/server-monitor.php
@@ -88,7 +88,7 @@ return [
 
     /*
      * When you connect to a ssh it should give you warning like a "POSSIBLE BREAK-IN ATTEMPT!"
-     * and it should fail your check so you can skip some errors with this. You need to just add
+     * and it can fail your check so you can skip some errors with this. You need to just add
      * unique part of error string and it will skip it.
      */
     'excluded_errors'=>[

--- a/config/server-monitor.php
+++ b/config/server-monitor.php
@@ -85,6 +85,19 @@ return [
      */
     'process_manipulator' => Spatie\ServerMonitor\Manipulators\Passthrough::class,
 
+
+    /*
+     * When you connect to a ssh it should give you warning like a "POSSIBLE BREAK-IN ATTEMPT!"
+     * and it should fail your check so you can skip some errors with this. You need to just add
+     * unique part of error string and it will skip it.
+     */
+    'excluded_errors'=>[
+
+        "POSSIBLE BREAK-IN ATTEMPT!",
+
+    ],
+
+
     /*
      * Thresholds for disk space's alert.
      */

--- a/src/CheckDefinitions/CheckDefinition.php
+++ b/src/CheckDefinitions/CheckDefinition.php
@@ -35,7 +35,7 @@ abstract class CheckDefinition
         $this->check->storeProcessOutput($process);
 
         try {
-            if (ExcludedErrors::hasExcludedError($process->getErrorOutput()) && ! empty($process->getErrorOutput())) {
+            if (!ExcludedErrors::hasExcludedError($process->getErrorOutput()) && ! empty($process->getErrorOutput())) {
                 $this->resolveFailed($process);
 
                 return;

--- a/src/CheckDefinitions/CheckDefinition.php
+++ b/src/CheckDefinitions/CheckDefinition.php
@@ -3,6 +3,7 @@
 namespace Spatie\ServerMonitor\CheckDefinitions;
 
 use Exception;
+use Spatie\ServerMonitor\Excluded\ExcludedErrors;
 use Spatie\ServerMonitor\Models\Check;
 use Symfony\Component\Process\Process;
 use Spatie\ServerMonitor\Models\Enums\CheckStatus;
@@ -34,7 +35,7 @@ abstract class CheckDefinition
         $this->check->storeProcessOutput($process);
 
         try {
-            if (! empty($process->getErrorOutput())) {
+            if (ExcludedErrors::hasExcludedError($process->getErrorOutput()) && ! empty($process->getErrorOutput())) {
                 $this->resolveFailed($process);
 
                 return;

--- a/src/Excluded/ExcludedErrors.php
+++ b/src/Excluded/ExcludedErrors.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: dd
+ * Date: 18.06.2018
+ * Time: 02:52
+ */
+
+namespace Spatie\ServerMonitor\Excluded;
+
+
+use phpDocumentor\Reflection\Types\Boolean;
+
+class ExcludedErrors
+{
+
+
+
+    public static function getExcludedErrors() : array
+    {
+
+        return config("server-monitor.excluded_errors");
+
+    }
+
+
+    public static function hasExcludedError(String $errorString) : Bool
+    {
+
+        $excludedErrors = self::getExcludedErrors();
+
+
+
+        foreach ($excludedErrors as $excludedError)
+        {
+            $counter=0;
+            str_replace($excludedError,"_REPLACE_",$errorString,$counter);
+            if($counter>0) return false;
+        }
+
+        return true;
+
+    }
+
+
+}

--- a/src/Excluded/ExcludedErrors.php
+++ b/src/Excluded/ExcludedErrors.php
@@ -35,10 +35,10 @@ class ExcludedErrors
         {
             $counter=0;
             str_replace($excludedError,"_REPLACE_",$errorString,$counter);
-            if($counter>0) return false;
+            if($counter>0) return true;
         }
 
-        return true;
+        return false;
 
     }
 

--- a/src/Excluded/ExcludedErrors.php
+++ b/src/Excluded/ExcludedErrors.php
@@ -9,6 +9,7 @@
 namespace Spatie\ServerMonitor\Excluded;
 
 
+use Illuminate\Support\Facades\Config;
 use phpDocumentor\Reflection\Types\Boolean;
 
 class ExcludedErrors
@@ -19,7 +20,7 @@ class ExcludedErrors
     public static function getExcludedErrors() : array
     {
 
-        return config("server-monitor.excluded_errors");
+        return Config::get("server-monitor.excluded_errors",[]);
 
     }
 

--- a/tests/Excluded/ExcludedErrorTest.php
+++ b/tests/Excluded/ExcludedErrorTest.php
@@ -16,7 +16,7 @@ class ExcludedErrorTest extends TestCase
     {
 
         //pretending like a error comes from SSH connection because i dont know how to emulate this situation
-        $error = "POSSIBLE BREAK-IN ATTEMPT!";
+        $error = "reverse mapping checking getaddrinfo for 192-168-1-243.foo.bar.net failed - POSSIBLE BREAK-IN ATTEMPT!";
 
 
 

--- a/tests/Excluded/ExcludedErrorTest.php
+++ b/tests/Excluded/ExcludedErrorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Spatie\ServerMonitor\Test\Excluded;
+
+use Spatie\ServerMonitor\Excluded\ExcludedErrors;
+use Spatie\ServerMonitor\Models\Check;
+use Symfony\Component\Process\Process;
+use Spatie\ServerMonitor\Test\TestCase;
+use Spatie\ServerMonitor\Manipulators\Manipulator;
+
+class ExcludedErrorTest extends TestCase
+{
+
+    /** @test */
+    public function testExcludedError()
+    {
+
+        //pretending like a error comes from SSH connection because i dont know how to emulate this situation
+        $error = "POSSIBLE BREAK-IN ATTEMPT!";
+
+
+
+        if(ExcludedErrors::hasExcludedError($error))
+        {
+            $this->assertTrue(true);
+            return;
+        }
+
+        $this->assertTrue(false);
+
+    }
+
+}


### PR DESCRIPTION
according to: https://www.electrictoolbox.com/reverse-mapping-possible-break-in-ssh/


ssh actually connects and its actually just a warning, but server-monitor thinks its something bad and gives fail.