### PR TITLE
fixed typo in diskspace check

### DIFF
--- a/src/CheckDefinitions/Diskspace.php
+++ b/src/CheckDefinitions/Diskspace.php
@@ -16,8 +16,8 @@ class Diskspace extends CheckDefinition
         $message = "usage at {$percentage}%";
 
         $thresholds = config('server-monitor.diskspace_percentage_threshold', [
-            'fail' => 80,
-            'warning' => 90,
+            'warning' => 80,
+            'fail' => 90,
         ]);
 
         if ($percentage >= $thresholds['fail']) {


### PR DESCRIPTION
The diskspace check class has a typo when attempting to get the threshold values from the config. The default values are reversed (warning v/s fail). Even though the default values would never be triggered if set in the config file, it makes it a difficult to read the class.

This PR fixes the typo!