### PR TITLE
Fix for #84 Memcached check not working out of the box?

### DIFF
--- a/src/CheckDefinitions/Memcached.php
+++ b/src/CheckDefinitions/Memcached.php
@@ -10,7 +10,7 @@ class Memcached extends CheckDefinition
 
     public function resolve(Process $process)
     {
-        if (str_contains($process->getOutput(), 'memcached is running')) {
+        if (str_contains($process->getOutput(), 'memcached is running')) || (str_contains($process->getOutput(), 'active (running)') ) {
             $this->check->succeed('is running');
 
             return;


### PR DESCRIPTION
Fix for #84 Memcached check not working out of the box?
Just adding a second condition based on a different memcached output:

```
service memcached status
● memcached.service - memcached daemon
   Loaded: loaded (/lib/systemd/system/memcached.service; enabled; vendor preset: enabled)
   Active: active (running) since Wed 2018-12-19 18:34:58 -03; 1h 1min ago
 Main PID: 1215 (memcached)
    Tasks: 6
   Memory: 1.0M
      CPU: 144ms
   CGroup: /system.slice/memcached.service
           └─1215 /usr/bin/memcached -m 64 -p 11211 -u memcache -l 127.0.0.1
```