### PR TITLE
Support IP addresses in Elasticsearch check.

### DIFF
--- a/src/CheckDefinitions/Elasticsearch.php
+++ b/src/CheckDefinitions/Elasticsearch.php
@@ -8,6 +8,19 @@ class Elasticsearch extends CheckDefinition
 {
     public $command = 'curl --silent http://localhost:9200';
 
+    public function command(): string
+    {
+        $command = $this->command;
+
+        $customIp = $this->check->getCustomProperty('ip');
+
+        if (!empty($customIp)) {
+            $command = str_replace('localhost', $customIp, $command);
+        }
+
+        return $command;
+    }
+
     public function resolve(Process $process)
     {
         $checkSucceeded = str_contains($process->getOutput(), 'lucene_version');

--- a/src/CheckDefinitions/Elasticsearch.php
+++ b/src/CheckDefinitions/Elasticsearch.php
@@ -14,7 +14,7 @@ class Elasticsearch extends CheckDefinition
 
         $customIp = $this->check->getCustomProperty('ip');
 
-        if (!empty($customIp)) {
+        if (! empty($customIp)) {
             $command = str_replace('localhost', $customIp, $command);
         }
 


### PR DESCRIPTION
This PR adds the possibility to check if Elasticsearch is running on a different IP than `localhost`.

You just have to add `{"ip": "XX.XX.XX.XX"}` to your `custom_properties` column of your check in the `checks` table.