### PR TITLE
Fix tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 All notable changes to `laravel-server-monitor` will be documented in this file
 
-## 1.5.0 - 2018-01-10
+## 1.5.0 - 2019-01-10
 
 - allow elastic search check to check other ips
 
-## 1.4.2 - 2018-01-10
+## 1.4.2 - 2019-01-10
 
 - fix memcached check
 

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "symfony/process": "~3.2|~3.3|~4.0"
     },
     "require-dev": {
-        "mockery/mockery": "~0.9|0.9.5|~1.0",
+        "mockery/mockery": "^0.9",
         "orchestra/testbench": "~3.5.0|~3.6.0|~3.7.0",
         "phpunit/phpunit": "~6.0|^6.3|^7.0"
     },

--- a/src/Models/Concerns/HasProcess.php
+++ b/src/Models/Concerns/HasProcess.php
@@ -31,10 +31,22 @@ trait HasProcess
         $sshCommandPrefix = config('server-monitor.ssh_command_prefix');
         $sshCommandSuffix = config('server-monitor.ssh_command_suffix');
 
-        return "ssh {$sshCommandPrefix} {$this->getTarget()} {$portArgument} {$sshCommandSuffix} 'bash -se <<$delimiter".PHP_EOL
+        $result = 'ssh';
+        if ($sshCommandPrefix) {
+            $result .= ' ' . $sshCommandPrefix;
+        }
+        $result .= ' ' . $this->getTarget();
+        if ($portArgument) {
+            $result .= ' ' . $portArgument;
+        }
+        if ($sshCommandSuffix) {
+            $result .= ' ' . $sshCommandSuffix;
+        }
+        $result .= " 'bash -se <<$delimiter".PHP_EOL
             .'set -e'.PHP_EOL
             .$definition->command().PHP_EOL
             .$delimiter."'";
+        return $result;
     }
 
     protected function getTarget(): string

--- a/src/Models/Concerns/HasProcess.php
+++ b/src/Models/Concerns/HasProcess.php
@@ -35,7 +35,7 @@ trait HasProcess
         if ($sshCommandPrefix) {
             $result .= ' '.$sshCommandPrefix;
         }
-        $result .= ' ' . $this->getTarget();
+        $result .= ' '.$this->getTarget();
         if ($portArgument) {
             $result .= ' '.$portArgument;
         }
@@ -46,7 +46,7 @@ trait HasProcess
             .'set -e'.PHP_EOL
             .$definition->command().PHP_EOL
             .$delimiter."'";
-        
+
         return $result;
     }
 

--- a/src/Models/Concerns/HasProcess.php
+++ b/src/Models/Concerns/HasProcess.php
@@ -33,19 +33,20 @@ trait HasProcess
 
         $result = 'ssh';
         if ($sshCommandPrefix) {
-            $result .= ' ' . $sshCommandPrefix;
+            $result .= ' '.$sshCommandPrefix;
         }
         $result .= ' ' . $this->getTarget();
         if ($portArgument) {
-            $result .= ' ' . $portArgument;
+            $result .= ' '.$portArgument;
         }
         if ($sshCommandSuffix) {
-            $result .= ' ' . $sshCommandSuffix;
+            $result .= ' '.$sshCommandSuffix;
         }
         $result .= " 'bash -se <<$delimiter".PHP_EOL
             .'set -e'.PHP_EOL
             .$definition->command().PHP_EOL
             .$delimiter."'";
+        
         return $result;
     }
 

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -64,6 +64,11 @@ class IntegrationTest extends TestCase
     /** @test */
     public function it_will_throttle_failed_notifications()
     {
+        $this->app['config']->set(
+            'server-monitor.notifications.notifications.'.CheckFailed::class,
+            ['slack']
+        );
+
         Notification::fake();
 
         $this->letSshServerRespondWithDiskspaceUsagePercentage(95);

--- a/tests/Models/Concerns/HasProcessTest.php
+++ b/tests/Models/Concerns/HasProcessTest.php
@@ -25,7 +25,7 @@ class HasProcessTest extends TestCase
     {
         $this->check->getProcessCommand();
 
-        $this->assertStringStartsWith("ssh my-host   'bash", $this->check->getProcessCommand());
+        $this->assertStringStartsWith("ssh my-host 'bash", $this->check->getProcessCommand());
     }
 
     /** @test */
@@ -38,7 +38,7 @@ class HasProcessTest extends TestCase
 
         $this->check->getProcessCommand();
 
-        $this->assertStringStartsWith("ssh my-host -p 123  'bash", $this->check->getProcessCommand());
+        $this->assertStringStartsWith("ssh my-host -p 123 'bash", $this->check->getProcessCommand());
     }
 
     /** @test */
@@ -51,7 +51,7 @@ class HasProcessTest extends TestCase
 
         $this->check->getProcessCommand();
 
-        $this->assertStringStartsWith("ssh my-ssh-user@my-host   'bash", $this->check->getProcessCommand());
+        $this->assertStringStartsWith("ssh my-ssh-user@my-host 'bash", $this->check->getProcessCommand());
     }
 
     /** @test */
@@ -64,7 +64,7 @@ class HasProcessTest extends TestCase
 
         $this->check->getProcessCommand();
 
-        $this->assertStringStartsWith("ssh 1.2.3.4   'bash", $this->check->getProcessCommand());
+        $this->assertStringStartsWith("ssh 1.2.3.4 'bash", $this->check->getProcessCommand());
     }
 
     /** @test */
@@ -81,7 +81,7 @@ class HasProcessTest extends TestCase
 
         $this->check->getProcessCommand();
 
-        $this->assertStringStartsWith("ssh {$prefix} 1.2.3.4   'bash", $this->check->getProcessCommand());
+        $this->assertStringStartsWith("ssh {$prefix} 1.2.3.4 'bash", $this->check->getProcessCommand());
     }
 
     /** @test */
@@ -98,6 +98,6 @@ class HasProcessTest extends TestCase
 
         $this->check->getProcessCommand();
 
-        $this->assertStringStartsWith("ssh 1.2.3.4  {$suffix} 'bash", $this->check->getProcessCommand());
+        $this->assertStringStartsWith("ssh 1.2.3.4 {$suffix} 'bash", $this->check->getProcessCommand());
     }
 }

--- a/tests/Notifications/EventHandlerTest.php
+++ b/tests/Notifications/EventHandlerTest.php
@@ -45,7 +45,7 @@ class EventHandlerTest extends TestCase
         $checkStatus
     ) {
         $this->app['config']->set(
-            'server-monitor.notifications.notifications.'.CheckSucceededNotification::class,
+            'server-monitor.notifications.notifications.'.$notificationClass,
             ['slack']
         );
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -46,6 +46,10 @@ abstract class TestCase extends Orchestra
      */
     protected function getEnvironmentSetUp($app)
     {
+        foreach ($app['config']->get('server-monitor.notifications.notifications') as $class => $notification) {
+            $app['config']->set('server-monitor.notifications.notifications', []);
+        }
+
         $app['config']->set('database.default', 'sqlite');
 
         $app['config']->set('mail.driver', 'log');


### PR DESCRIPTION
Currently CI fails so that merge requests are blocked. This PR fixes the failing tests. There were several problems: 
* mockery 1.0 breaks BC, so some tests were failing
* there was a problem how strings were concatenated when building ssh commands
* there were globally set slack notifications - for which there was no implementation in laravel<5.7
* for some tests any kind of notification must be set

closes #91 
closes #78 