### PR TITLE
Replace new Process with Process::fromShellCommandline

### DIFF
--- a/src/Models/Concerns/HasProcess.php
+++ b/src/Models/Concerns/HasProcess.php
@@ -10,7 +10,7 @@ trait HasProcess
     public function getProcess(): Process
     {
         return blink()->once("process.{$this->id}", function () {
-            $process = new Process($this->getProcessCommand());
+            $process = Process::fromShellCommandline($this->getProcessCommand());
 
             $process->setTimeout($this->getDefinition()->timeoutInSeconds());
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -104,7 +104,7 @@ abstract class TestCase extends Orchestra
 
     protected function getSuccessfulProcessWithOutput(string $output = 'my output'): Process
     {
-        $process = new Process("echo {$output}");
+        $process = Process::fromShellCommandline("echo {$output}");
 
         $process->start();
 
@@ -116,7 +116,7 @@ abstract class TestCase extends Orchestra
 
     protected function getFailedProcess(): Process
     {
-        $process = new Process('blablabla');
+        $process = Process::fromShellCommandline('blablabla');
 
         $process->start();
 
@@ -182,7 +182,7 @@ abstract class TestCase extends Orchestra
 
     protected function skipIfDummySshServerIsNotRunning()
     {
-        if ((new Process('ssh localhost -p 65000 "echo"'))->run() === 255) {
+        if ((Process::fromShellCommandline('ssh localhost -p 65000 "echo"'))->run() === 255) {
             $this->markTestSkipped('Dummy SSH server is not running.');
         }
     }


### PR DESCRIPTION
Suppress the deprecated notice from symfony/process 

I can't make the dummy ssh server works, so 8 tests were skipped...

BTW, thank you for this package and for many others !