### PR TITLE
Allow Guzzle 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "ext-json": "*",
         "php": "^7.2",
-        "guzzlehttp/guzzle": "^6.3",
+        "guzzlehttp/guzzle": "^6.3|^7.0",
         "laravel/framework": "^6.0|^7.0",
         "spatie/laravel-blink": "^1.3",
         "spatie/regex": "^1.1",


### PR DESCRIPTION
Guzzle isn't actually used directly within this package, so there shouldn't be any major issue with allowing the newer version for apps that support it.