### PR TITLE
fix for deprecated Model "Dates" Property

### DIFF
--- a/src/Models/Check.php
+++ b/src/Models/Check.php
@@ -30,10 +30,9 @@ class Check extends Model
     public $casts = [
         'custom_properties' => 'array',
         'last_run_output' => 'array',
-    ];
-
-    public $dates = [
-        'last_ran_at', 'next_check_at', 'started_throttling_failing_notifications_at',
+        'last_ran_at' => 'datetime',
+        'next_check_at' => 'datetime',
+        'started_throttling_failing_notifications_at' => 'datetime',
     ];
 
     public function host(): BelongsTo


### PR DESCRIPTION
The `$dates` property was deprecated in Laravel 10 and moved into the `$casts` property accordingly.

https://laravel.com/docs/10.x/upgrade#model-dates-property