### PR TITLE
- Add a check for MariaDB, as the daemon name is different than MySQL's on recent versions

### DIFF
--- a/config/server-monitor.php
+++ b/config/server-monitor.php
@@ -12,6 +12,7 @@ return [
         'elasticsearch' => Spatie\ServerMonitor\CheckDefinitions\Elasticsearch::class,
         'memcached' => Spatie\ServerMonitor\CheckDefinitions\Memcached::class,
         'mysql' => Spatie\ServerMonitor\CheckDefinitions\MySql::class,
+        'mariadb' => Spatie\ServerMonitor\CheckDefinitions\MariaDb::class,
     ],
 
     /*

--- a/src/CheckDefinitions/MariaDb.php
+++ b/src/CheckDefinitions/MariaDb.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Spatie\ServerMonitor\CheckDefinitions;
+
+use Illuminate\Support\Str;
+use Symfony\Component\Process\Process;
+
+class MariaDb extends CheckDefinition
+{
+    public $command = 'ps -e | grep mariadbd$';
+
+    public function resolve(Process $process)
+    {
+        if (Str::contains($process->getOutput(), 'mariadb')) {
+            $this->check->succeed('is running');
+
+            return;
+        }
+
+        $this->check->fail('is not running');
+    }
+}

--- a/tests/CheckDefinitions/MariaDbTest.php
+++ b/tests/CheckDefinitions/MariaDbTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use Spatie\ServerMonitor\Models\Check;
+use Spatie\ServerMonitor\CheckDefinitions\MariaDb;
+use Spatie\ServerMonitor\Models\Enums\CheckStatus;
+
+beforeEach(function () {
+    $this->createHost('localhost', 65000, ['elasticsearch']);
+
+    $this->check = Check::first();
+
+    $this->mariaDbCheckDefintion = (new MariaDb())->setCheck($this->check);
+});
+
+it('can determine success', function () {
+    $process = $this->getSuccessfulProcessWithOutput(
+        '1410 ?    00:20:36 mariadbd'
+    );
+
+    $this->mariaDbCheckDefintion->resolve($process);
+
+    $this->check->fresh();
+
+    expect($this->check->last_run_message)->toContain('is running');
+    expect($this->check->status)->toEqual(CheckStatus::SUCCESS);
+});
+
+it('can determine failure', function () {
+    $process = $this->getSuccessfulProcessWithOutput(
+        ''
+    );
+
+    $this->mariaDbCheckDefintion->resolve($process);
+
+    $this->check->fresh();
+
+    expect($this->check->last_run_message)->toContain('is not running');
+    expect($this->check->status)->toEqual(CheckStatus::FAILED);
+});


### PR DESCRIPTION
Hello,


I had to write a different check for MariaDB after an update, and just though I would share it with everyone else :-)


Let me know if anything is missing or incomplete