### PR TITLE
Add type hint to fix deprecation message

### DIFF
--- a/src/CheckCollection.php
+++ b/src/CheckCollection.php
@@ -57,10 +57,7 @@ class CheckCollection implements Countable
         $finishedChecks->each->handleFinishedProcess();
     }
 
-    /**
-     * @return int
-     */
-    public function count()
+    public function count(): int
     {
         return count($this->pendingChecks);
     }


### PR DESCRIPTION
Just a small commit to fix this warning when you have the deprecation log enabled:

`local.WARNING: Return type of Spatie\ServerMonitor\CheckCollection::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /var/www/html/vendor/spatie/laravel-server-monitor/src/CheckCollection.php on line 59`