### PR TITLE
Add missing documentation about `Host` model

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,13 @@ return [
     ],
 
     /*
+     * To add or modify behaviour to the `Host` model you can specify your
+     * own model here. The only requirement is that they should
+     * extend the `Host` model provided by this package.
+     */
+    'host_model' => Spatie\ServerMonitor\Models\Host::class,
+
+    /*
      * To add or modify behaviour to the `Check` model you can specify your
      * own model here. The only requirement is that they should
      * extend the `Check` model provided by this package.


### PR DESCRIPTION
I copied missing documentation about extending the `Host` model from the config file to `README.md`.